### PR TITLE
Update 0_create_cohort_table.sql

### DIFF
--- a/0_create_cohort_table.sql
+++ b/0_create_cohort_table.sql
@@ -1,24 +1,26 @@
-CREATE OR REPLACE VIEW public.cohort_table
-AS WITH customer_info AS (
-         SELECT c.customerkey,
-            s.orderdate,
-            sum(s.exchangerate * s.netprice * s.quantity::double precision) AS client_revenue,
-            count(*) AS items_purchased,
-            c.countryfull,
-            c.age,
-            concat(TRIM(BOTH FROM c.givenname), ' ', TRIM(BOTH FROM c.surname)) AS full_name
-           FROM sales s
-             JOIN customer c ON s.customerkey = c.customerkey
-          GROUP BY c.customerkey, s.orderdate
-          ORDER BY c.customerkey
-        )
- SELECT customerkey,
+CREATE OR REPLACE VIEW public.cohort_table AS
+WITH customer_info AS (
+    SELECT 
+        c.customerkey,
+        s.orderdate,
+        SUM(s.exchangerate * s.netprice * s.quantity::double precision) AS client_revenue,
+        COUNT(*) AS items_purchased,
+        c.countryfull,
+        c.age,
+        CONCAT(TRIM(c.givenname), ' ', TRIM(c.surname)) AS full_name
+    FROM sales s
+    INNER JOIN customer c 
+        ON s.customerkey = c.customerkey
+    GROUP BY c.customerkey, s.orderdate, c.countryfull, c.age, c.givenname, c.surname
+)
+SELECT 
+    customerkey,
     orderdate,
     client_revenue,
     items_purchased,
     countryfull,
     age,
     full_name,
-    min(orderdate) OVER (PARTITION BY customerkey) AS first_order,
-    EXTRACT(year FROM min(orderdate) OVER (PARTITION BY customerkey)) AS cohort_year
-   FROM customer_info;
+    MIN(orderdate) OVER (PARTITION BY customerkey) AS first_order,
+    EXTRACT(YEAR FROM MIN(orderdate) OVER (PARTITION BY customerkey)) AS cohort_year
+FROM customer_info;


### PR DESCRIPTION
The improved version of the code focuses on clarity, correctness, and efficiency. First, the unnecessary `ORDER BY` inside the CTE was removed since PostgreSQL ignores ordering there unless combined with `LIMIT/OFFSET`, which only added overhead. Next, all non-aggregated columns such as `countryfull`, `age`, `givenname`, and `surname` were explicitly added to the `GROUP BY` clause to ensure proper aggregation and avoid potential errors in stricter PostgreSQL versions. The `TRIM` function was simplified, since `TRIM()` by default removes both leading and trailing spaces, making `TRIM(BOTH FROM …)` redundant. The join was made more explicit by using `INNER JOIN` instead of just `JOIN` to improve readability. Lastly, the SQL was reformatted with consistent indentation and alignment of keywords to make the code easier to read and maintain. These changes together enhance both the correctness and maintainability of the query without altering its output.